### PR TITLE
[HOCS-5145] Adding SQS connectivity with test messages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,11 @@ plugins {
 	id 'org.springframework.boot' version '2.6.7'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'java'
+	id "io.freefair.lombok" version "6.4.3"
 }
-
+apply plugin: 'java'
+apply plugin: 'idea'
+apply plugin: 'io.spring.dependency-management'
 group = 'uk.gov.digital.ho.hocs'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
@@ -13,13 +16,17 @@ repositories {
 }
 
 dependencies {
+	implementation group: 'com.amazonaws', name: 'aws-java-sdk', version: '1.12.137'
+	implementation('org.springframework.boot:spring-boot-starter-validation')
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'com.github.javafaker:javafaker:1.0.2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation group: 'com.microsoft.sqlserver', name: 'mssql-jdbc', version: '6.1.0.jre8'
 	testImplementation group: 'com.h2database', name: 'h2', version: '1.3.148'
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/java/uk/gov/digital/ho/hocs/aws/LocalStackConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/aws/LocalStackConfiguration.java
@@ -1,0 +1,50 @@
+package uk.gov.digital.ho.hocs.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile({"local"})
+public class LocalStackConfiguration {
+
+    @Value("${aws.sqs.region}")
+    private String region;
+    @Value("${aws.local-host}")
+    private String awsHost;
+
+    private final AWSCredentialsProvider awsCredentialsProvider = new AWSCredentialsProvider() {
+
+        @Override
+        public AWSCredentials getCredentials() {
+            return new BasicAWSCredentials("fake", "fake");
+        }
+
+        @Override
+        public void refresh() {
+
+        }
+    };
+
+    @Primary
+    @Bean
+    public AmazonSQSAsync sqsClient() {
+        String host = String.format("http://%s:4576/", awsHost);
+        AwsClientBuilder.EndpointConfiguration endpoint = new AwsClientBuilder.EndpointConfiguration(host, region);
+        return AmazonSQSAsyncClientBuilder.standard()
+                .withClientConfiguration(new ClientConfiguration().withProtocol(Protocol.HTTP))
+                .withCredentials(awsCredentialsProvider)
+                .withEndpointConfiguration(endpoint)
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/aws/SQSConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/aws/SQSConfiguration.java
@@ -1,0 +1,42 @@
+package uk.gov.digital.ho.hocs.aws;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.util.StringUtils;
+
+@Configuration
+@Profile({"sqs"})
+public class SQSConfiguration {
+
+    @Bean
+    public AmazonSQSAsync sqsClient(@Value("${aws.sqs.access-key}") String accessKey,
+                               @Value("${aws.sqs.secret-key}") String secretKey,
+                               @Value("${aws.sqs.region}") String region) {
+
+        if (!StringUtils.hasText(accessKey)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank value for access key");
+        }
+
+        if (!StringUtils.hasText(secretKey)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank values for secret key");
+        }
+
+        if (!StringUtils.hasText(region)) {
+            throw new BeanCreationException("Failed to create SQS client bean. Need non-blank values for region: " + region);
+        }
+
+        return AmazonSQSAsyncClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey)))
+                .withClientConfiguration(new ClientConfiguration())
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/client/MessageService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/MessageService.java
@@ -1,0 +1,55 @@
+package uk.gov.digital.ho.hocs.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.digital.ho.hocs.client.SQSClient;
+import uk.gov.digital.ho.hocs.payload.PayloadFile;
+import uk.gov.digital.ho.hocs.payload.Replacer;
+
+import java.util.Random;
+
+import static org.apache.commons.lang3.StringUtils.replaceEach;
+import static uk.gov.digital.ho.hocs.payload.FileReader.getResourceFileAsString;
+
+@Service
+@Slf4j
+public class MessageService {
+
+    private final SQSClient sqsClient;
+    private final int numMessages;
+    private final String complaintType;
+    private final Replacer replacer = new Replacer();
+
+    public MessageService(SQSClient sqsClient,
+                          @Value("${run.config.num-messages}") int numMessages,
+                          @Value("${run.config.complaint-type}")  String complaintType) {
+        this.sqsClient = sqsClient;
+        this.numMessages = numMessages;
+        this.complaintType = complaintType;
+    }
+
+    public void startSending() {
+
+        if (!StringUtils.isEmpty(complaintType)) {
+            for (int i = 0; i < numMessages; i++) {
+                String fileName = PayloadFile.valueOf(complaintType).getFileName();
+                log.info("Sending {} : {}", complaintType, fileName);
+//                sqsClient.sendMessage("Test Message");
+                String msg= replaceEach(getResourceFileAsString(fileName), replacer.getSearchList(), replacer.getReplaceList());
+                sqsClient.sendMessage(msg);
+            }
+            log.info("Successfully sent {}, {} messages.", numMessages, complaintType);
+        } else {
+            new Random().ints(numMessages, 1, PayloadFile.values().length).forEach((typeIndex) -> {
+                String fileName = PayloadFile.values()[typeIndex].getFileName();
+                log.info("Sending Random : {}", fileName);
+                sqsClient.sendMessage(replaceEach(getResourceFileAsString(fileName), replacer.getSearchList(), replacer.getReplaceList()));
+            });
+            log.info("Successfully sent {}, random messages.", numMessages);
+        }
+
+        sqsClient.read();
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/client/SQSClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/SQSClient.java
@@ -1,0 +1,45 @@
+package uk.gov.digital.ho.hocs.client;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.amazonaws.services.sqs.model.ReceiveMessageResult;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SQSClient {
+
+    private final AmazonSQSAsync sqs;
+    private final String queueUrl;
+
+    @Autowired
+    public SQSClient(AmazonSQSAsync sqs,
+                     @Value("${run.config.queue-name}")  String queueName) {
+        this.sqs = sqs;
+        this.queueUrl = sqs.getQueueUrl(queueName).getQueueUrl();
+    }
+    
+    public void sendMessage(String message) {
+        SendMessageRequest send_msg_request = new SendMessageRequest()
+                .withQueueUrl(queueUrl)
+                .withMessageBody(message);
+
+        SendMessageResult sendMessageResult = sqs.sendMessage(send_msg_request);
+
+        log.info("Successfully sent MessageId: {} ,queueURL: {}", sendMessageResult.getMessageId(), queueUrl);
+    }
+    public void read() {
+        ReceiveMessageRequest receive_msg_request = new ReceiveMessageRequest()
+                .withQueueUrl(queueUrl);
+
+        ReceiveMessageResult receiveMessageResult = sqs.receiveMessage(receive_msg_request);
+
+        log.info("Successfully received Message: {} ,queueURL: {}", receiveMessageResult.getMessages().get(0), queueUrl);
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/cms/HocsCmsDataMigrator.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/cms/HocsCmsDataMigrator.java
@@ -1,13 +1,29 @@
 package uk.gov.digital.ho.hocs.cms;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import uk.gov.digital.ho.hocs.client.MessageService;
 
 @SpringBootApplication
-public class HocsCmsDataMigrator {
+@ComponentScan(basePackages = {"com.amazonaws.services.sqs", "uk.gov.digital.ho.hocs"})
+@Slf4j
+public class HocsCmsDataMigrator implements CommandLineRunner {
 
-	public static void main(String[] args) {
-		SpringApplication.run(HocsCmsDataMigrator.class, args);
+	private final MessageService messageService;
+
+	public HocsCmsDataMigrator(MessageService messageService) {
+		this.messageService = messageService;
 	}
 
+	@Override
+	public void run(String... args) {
+		messageService.startSending();
+	}
+
+	public static void main(String[] args) {
+		SpringApplication.run(uk.gov.digital.ho.hocs.cms.HocsCmsDataMigrator.class, args);
+	}
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/config/AWSCustomConfig.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/config/AWSCustomConfig.java
@@ -1,0 +1,32 @@
+package uk.gov.digital.ho.hocs.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import javax.validation.constraints.NotBlank;
+
+@Configuration
+@ConfigurationProperties(prefix = "aws")
+@Getter
+@Setter
+public class AWSCustomConfig {
+
+    @NotBlank
+    private SQSCustomProperties sqs;
+    @NotBlank
+    private String localHost;
+
+    @Getter
+    @Setter
+    private static class SQSCustomProperties {
+        @NotBlank
+        private String region;
+        @NotBlank
+        private String accessKey;
+        @NotBlank
+        private String secretKey;
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/config/AppCustomProperties.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/config/AppCustomProperties.java
@@ -1,0 +1,21 @@
+package uk.gov.digital.ho.hocs.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import javax.validation.constraints.NotBlank;
+
+@Configuration
+@ConfigurationProperties(prefix = "run.config")
+@Getter
+@Setter
+public class AppCustomProperties {
+    @NotBlank
+    private String queueName;
+    @NotBlank
+    private Integer numMessages;
+
+    private String complaintType;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/payload/FileReader.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/payload/FileReader.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.payload;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class FileReader {
+
+    public static String getResourceFileAsString(String fileName) {
+        InputStream is = getResourceFileAsInputStream(fileName);
+        if (is != null) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+        } else {
+            throw new RuntimeException("resource not found");
+        }
+    }
+
+    private static InputStream getResourceFileAsInputStream(String fileName) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(fileName);
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/payload/PayloadFile.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/payload/PayloadFile.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.payload;
+
+import lombok.Getter;
+
+@Getter
+public enum PayloadFile {
+    BIOMETRIC("templates/biometric.json"),
+    DECISION("templates/decision.json"),
+    DELAYS("templates/delays.json"),
+    EXISTING("templates/existing.json"),
+    MAKING_APPOINTMENT("templates/makingAppointment.json"),
+    POOR_INFORMATION("templates/poorInformation.json"),
+    REFUND("templates/refund.json"),
+    SOMETHING_ELSE("templates/somethingElse.json"),
+    STAFF_BEHAVIOUR("templates/staffBehaviour.json"),
+    SUBMITTING_APPLICATION("templates/submittingApplication.json");
+
+    private final String fileName;
+
+    PayloadFile(String fileName) {
+        this.fileName = fileName;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/payload/Replacer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/payload/Replacer.java
@@ -1,0 +1,31 @@
+package uk.gov.digital.ho.hocs.payload;
+
+import lombok.Getter;
+
+@Getter
+public class Replacer {
+
+    private final String[] searchList = {
+            "@@TODAY@@",
+            "@@COMPLAINT_TEXT@@",
+            "@@APPLICANT_NAME@@",
+            "@@AGENT_NAME@@",
+            "@@NATIONALITY@@",
+            "@@COUNTRY@@",
+            "@@CITY@@",
+            "@@DOB@@",
+            "@@APPLICANT_EMAIL@@",
+            "@@AGENT_EMAIL@@",
+            "@@PHONE@@",
+            "@@REFERENCE@@"
+    };
+
+    public String[] getReplaceList() {
+        String[] replaceList = new String[searchList.length];
+        for (int i = 0; i < searchList.length; i++) {
+            String token = searchList[i];
+            replaceList[i] = TokenReplacer.replaceToken(token);
+        }
+        return replaceList;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/payload/TokenReplacer.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/payload/TokenReplacer.java
@@ -1,0 +1,54 @@
+package uk.gov.digital.ho.hocs.payload;
+
+import com.github.javafaker.Faker;
+import com.github.javafaker.service.FakeValuesService;
+import com.github.javafaker.service.RandomService;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Locale;
+
+public class TokenReplacer {
+    private static final FakeValuesService fakeValuesService = new FakeValuesService(
+            new Locale("en-GB"), new RandomService());
+    private static final Faker faker = new Faker();
+
+    public static String replaceToken(String token) {
+        switch (token) {
+            case "@@TODAY@@":
+                return LocalDateTime.now().format(DateTimeFormatter.ISO_DATE);
+            case "@@COMPLAINT_TEXT@@":
+                return faker.lorem().paragraph();
+            case "@@APPLICANT_NAME@@":
+            case "@@AGENT_NAME@@":
+                return faker.name().fullName();
+            case "@@NATIONALITY@@":
+            case "@@COUNTRY@@":
+                return faker.country().name();
+            case "@@CITY@@":
+                return faker.address().city();
+            case "@@DOB@@":
+                return convertToLocalDate(faker.date().birthday()).format(DateTimeFormatter.ISO_DATE);
+            case "@@APPLICANT_EMAIL@@":
+            case "@@AGENT_EMAIL@@":
+                return faker.internet().safeEmailAddress();
+            case "@@PHONE@@":
+                return "0114 4960999";
+            case "@@REFERENCE@@":
+                return fakeValuesService.regexify("[a-z1-9]{10}");
+            default:
+                return "Unknown Token";
+        }
+    }
+
+
+    public static LocalDate convertToLocalDate(Date date) {
+        return Instant.ofEpochMilli(date.getTime())
+                .atZone(ZoneId.systemDefault())
+                .toLocalDate();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,11 @@ spring.datasource.driverClassName=com.microsoft.sqlserver.jdbc.SQLServerDriver
 spring.datasource.url=jdbc:sqlserver://${db.host:localhost}:${db.port:5434};databaseName=LaganECM
 spring.datasource.username=${db.username:sa}
 spring.datasource.password=${db.password}
+
+## Uncommment the below Properties when running locally
+# spring.datasource.url=jdbc:sqlserver://localhost:5434;databaseName=LaganECM
+# spring.datasource.username=sa
+# spring.datasource.password=Sqladmin-1
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql = true
 
@@ -11,5 +16,15 @@ spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.SQLServer2016Dia
 
 # Hibernate ddl auto (create, create-drop, validate, update)
 spring.jpa.hibernate.ddl-auto = update
+
+## aws SQS Properties
+aws.local-host=localstack
+aws.sqs.region=eu-west-2
+aws.sqs.access-key=fake
+aws.sqs.secret-key=fake
+
+run.config.queue-name=document-queue
+run.config.num-messages=1
+run.config.complaint-type=SOMETHING_ELSE
 
 management.health.probes.enabled=true

--- a/src/main/resources/templates/biometric.json
+++ b/src/main/resources/templates/biometric.json
@@ -1,0 +1,22 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "BIOMETRIC_RESIDENCE_PERMIT",
+    "reference": {
+      "referenceType": "GWF_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "problemExperienced": "CARD_INCORRECT"
+    }
+  }
+}

--- a/src/main/resources/templates/decision.json
+++ b/src/main/resources/templates/decision.json
@@ -1,0 +1,23 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "IMMIGRATION_DECISION",
+    "reference": {
+      "referenceType": "IHS_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "decisionOutcome": "POSITIVE",
+      "applicationLocation": "INSIDE_UK"
+    }
+  }
+}

--- a/src/main/resources/templates/delays.json
+++ b/src/main/resources/templates/delays.json
@@ -1,0 +1,24 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "DELAYS",
+    "reference": {
+      "referenceType": "HO_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "delayedWaitingFor": "APPLICATION_DELAY",
+      "applicationSubmittedWhen": "Lorem",
+      "applicationLocation": "INSIDE_UK"
+    }
+  }
+}

--- a/src/main/resources/templates/existing.json
+++ b/src/main/resources/templates/existing.json
@@ -1,0 +1,20 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "EXISTING",
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "previousComplaint": {
+        "previousComplaintType": "IMMIGRATION_DECISION"
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/makingAppointment.json
+++ b/src/main/resources/templates/makingAppointment.json
@@ -1,0 +1,23 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "MAKING_APPOINTMENT",
+    "reference": {
+      "referenceType": "GWF_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "problemExperienced": "TECHNICAL_APPOINTMENTS",
+      "applicationLocation": "INSIDE_UK"
+    }
+  }
+}

--- a/src/main/resources/templates/poorInformation.json
+++ b/src/main/resources/templates/poorInformation.json
@@ -1,0 +1,21 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "POOR_INFORMATION",
+    "reference": {
+      "referenceType": "UAN_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@"
+    }
+  }
+}

--- a/src/main/resources/templates/refund.json
+++ b/src/main/resources/templates/refund.json
@@ -1,0 +1,29 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "REFUND",
+    "reference": {
+      "referenceType": "IHS_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "AGENT",
+      "applicantDetails": {
+        "applicantName": "@@APPLICANT_NAME@@",
+        "applicantNationality": "@@NATIONALITY@@",
+        "applicantDob": "@@DOB@@"
+      },
+      "agentDetails": {
+        "agentName": "@@AGENT_NAME@@",
+        "agentType": "LEGAL_REP",
+        "agentEmail": "@@AGENT_EMAIL@@"
+      }
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "refundRequested": "YES",
+      "applicationLocation": "INSIDE_UK",
+      "refundType": "STANDARD"
+    }
+  }
+}

--- a/src/main/resources/templates/somethingElse.json
+++ b/src/main/resources/templates/somethingElse.json
@@ -1,0 +1,21 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "SOMETHING_ELSE",
+    "reference": {
+      "referenceType": "HO_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@"
+    }
+  }
+}

--- a/src/main/resources/templates/staffBehaviour.json
+++ b/src/main/resources/templates/staffBehaviour.json
@@ -1,0 +1,34 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "POOR_STAFF_BEHAVIOUR",
+    "reference": {
+      "referenceType": "IHS_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "AGENT",
+      "applicantDetails": {
+        "applicantName": "@@APPLICANT_NAME@@",
+        "applicantNationality": "@@NATIONALITY@@",
+        "applicantDob": "@@DOB@@"
+      },
+      "agentDetails": {
+        "agentName": "@@AGENT_NAME@@",
+        "agentType": "RELATIVE",
+        "agentEmail": "@@AGENT_EMAIL@@"
+      }
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "experience": {
+        "experienceType": "FACE_TO_FACE",
+        "location": {
+          "country": "@@COUNTRY@@",
+          "city": "@@CITY@@",
+          "centreType": "VAC"
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/templates/submittingApplication.json
+++ b/src/main/resources/templates/submittingApplication.json
@@ -1,0 +1,23 @@
+{
+  "creationDate": "@@TODAY@@",
+  "complaint": {
+    "complaintType": "SUBMITTING_APPLICATION",
+    "reference": {
+      "referenceType": "IHS_REF",
+      "reference": "@@REFERENCE@@"
+    },
+    "reporterDetails": {
+      "applicantType": "APPLICANT",
+      "applicantName": "@@APPLICANT_NAME@@",
+      "applicantNationality": "@@NATIONALITY@@",
+      "applicantDob": "@@DOB@@",
+      "applicantEmail": "@@APPLICANT_EMAIL@@",
+      "applicantPhone": "@@PHONE@@"
+    },
+    "complaintDetails": {
+      "complaintText": "@@COMPLAINT_TEXT@@",
+      "problemExperienced": "SOMETHING_ELSE",
+      "applicationLocation": "OUTSIDE_UK"
+    }
+  }
+}


### PR DESCRIPTION
Added an SQS Client that uses com.amazonaws.services.sqs.AmazonSQSAsync to send and receive messages to the queue.

SQS Queue configurations are defined in LocalStackConfiguration and SQSConfiguration classes.

Dependent on localstack with SQS 

## Uncommment the below Properties when running locally and comment the other three
# spring.datasource.url=jdbc:sqlserver://localhost:5434;databaseName=LaganECM
# spring.datasource.username=sa
# spring.datasource.password=Sqladmin-1

pass VM options 
-Dspring.profiles.active=development,local